### PR TITLE
Added fix for Issuse #1

### DIFF
--- a/.devcontainer/ros2/Dockerfile
+++ b/.devcontainer/ros2/Dockerfile
@@ -1,13 +1,20 @@
 FROM ros:humble
 
+ARG USERNAME=developer
+ARG USER_GID=1000
+ARG USER_UID=1000
+
 # Install sudo
 RUN apt-get update &&\
     apt-get install -y sudo openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user called "developer" with sudo privileges
-RUN useradd -m -s /bin/bash developer && \
-    echo "developer ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers 
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \
+    && echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME} \
+    && chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
 RUN mkdir -p /home/developer/.ssh
 

--- a/.devcontainer/ros2/compose.yml
+++ b/.devcontainer/ros2/compose.yml
@@ -4,10 +4,8 @@ services:
     volumes:
       - ../../.:/workspace/.
       - /tmp/.X11-unix:/tmp/.X11-unix # Expose X11 socket
-      - ${XAUTHORITY:-$HOME/.Xauthority}:/home/developer/.Xauthority # Mount Xauthority file
     environment:
       - SSH_KEY=$SSH_KEY
       - DISPLAY=${DISPLAY}
-      - XAUTHORITY=/home/developer/.Xauthority # Set Xauthority file path
     command: sleep infinity
     user: developer

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# ROS2-DEV 
+
+## Steps to Grant X11 Socket Permission:
+
+1) Manually Grant Access:
+
+- Run the following command on your host system to grant X11 access to the local user:
+```
+xhost +SI:localuser:$USER
+```
+
+2) Automate Permission on Startup:
+
+- To avoid typing the command every time you restart your PC or laptop, you can automate this by adding it to your ~/.profile file.
+
+- Add the following line to ~/.profile:
+```
+echo "xhost +SI:localuser:$USER" >> ~/.profiles
+```
+**NOTE:** This approach assumes that the user created inside the Docker container has the same UID as the host user. If the UID does not match, you might encounter permission issues.
+
+
+## TODO
+
 add a readme
 add ros2-devcontaioner like admiring samples ,
 add about windows, codespaces, and linux support, 


### PR DESCRIPTION
# Fix for [Issue #1](https://github.com/RishikesavanRamesh/ROS2-DEV/issues/1)

To address this, you can use xhost to grant access to the X11 server for the local user, bypassing the need to mount the Xauthority file.